### PR TITLE
Modified the remediation logic to check for protocol udp instead of tcp as the remediation is for closing the open udp port for memcache

### DIFF
--- a/remediation_worker/jobs/aws_ec2_close_port_11211/aws_ec2_close_port_11211.py
+++ b/remediation_worker/jobs/aws_ec2_close_port_11211/aws_ec2_close_port_11211.py
@@ -84,7 +84,7 @@ class EC2ClosePort11211(object):
                 )
                 for rule in security_group_rules["SecurityGroupRules"]:
                     if (
-                        rule["IpProtocol"] == "tcp"
+                        rule["IpProtocol"] == "udp"
                         and rule["IsEgress"] is False
                         and rule["FromPort"] <= port
                         and rule["ToPort"] >= port


### PR DESCRIPTION
This commit includes the updates for modifying the protocol to be checked to udp instead of tcp as port 11211 is the udp port of memcache