### PR TITLE
PLA-45823 - Updated aws_s3_bucket_policy_allow_https.py remediation job

### DIFF
--- a/remediation_worker/jobs/aws_s3_bucket_policy_allow_https/aws_s3_bucket_policy_allow_https.py
+++ b/remediation_worker/jobs/aws_s3_bucket_policy_allow_https/aws_s3_bucket_policy_allow_https.py
@@ -103,7 +103,7 @@ class S3AllowOnlyHttpsRequest:
                 "Sid": "Restrict Non-https Requests",
                 "Effect": "Deny",
                 "Principal": "*",
-                "Action": "s3:GetObject",
+                "Action": "s3:*",
                 "Resource": f"arn:aws:s3:::{bucket_name}/*",
                 "Condition": {"Bool": {"aws:SecureTransport": "false"}},
             }

--- a/test/unit/test_aws_s3_bucket_policy_allow_https.py
+++ b/test/unit/test_aws_s3_bucket_policy_allow_https.py
@@ -98,7 +98,7 @@ class TestCloudtrailS3PublicAccess(object):
                     "Sid": "Restrict Non-https Requests",
                     "Effect": "Deny",
                     "Principal": "*",
-                    "Action": "s3:GetObject",
+                    "Action": "s3:*",
                     "Resource": "arn:aws:s3:::bucket_name/*",
                     "Condition": {"Bool": {"aws:SecureTransport": "false"}},
                 },


### PR DESCRIPTION
Updated aws_s3_bucket_policy_allow_https.py remediation job as we've updated the corresponding rule to search for "Action": "s3:*"  instead of "Action": "s3:GetObject".